### PR TITLE
에러 메시지 언어가 lang쿼리 스트링에 맞게 변경되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/jakduk/api/ApiApplication.java
+++ b/src/main/java/com/jakduk/api/ApiApplication.java
@@ -1,5 +1,7 @@
 package com.jakduk.api;
 
+import java.util.Locale;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -11,6 +13,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class ApiApplication {
 
     public static void main(String[] args) {
+        Locale.setDefault(Locale.ENGLISH);
         SpringApplication.run(ApiApplication.class, args);
     }
 }

--- a/src/main/java/com/jakduk/api/exception/ServiceError.java
+++ b/src/main/java/com/jakduk/api/exception/ServiceError.java
@@ -1,11 +1,11 @@
 package com.jakduk.api.exception;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
 import lombok.Getter;
 import org.apache.http.HttpStatus;
 import org.springframework.context.i18n.LocaleContextHolder;
-
-import java.util.Locale;
-import java.util.ResourceBundle;
 
 /**
  * @author pyohwan
@@ -70,11 +70,14 @@ public enum ServiceError {
     private final String message;
 
     ServiceError(Integer httpStatus, String message) {
-        Locale locale = LocaleContextHolder.getLocale();
-        ResourceBundle resourceBundle = ResourceBundle.getBundle("messages.exception", locale);
-
         this.httpStatus = httpStatus;
         this.code = this.name();
-        this.message = resourceBundle.getString(message);
+        this.message = message;
+    }
+
+    public String getMessage() {
+        Locale locale = LocaleContextHolder.getLocaleContext().getLocale();
+        ResourceBundle resourceBundle = ResourceBundle.getBundle("messages.exception", locale);
+        return resourceBundle.getString(message);
     }
 }


### PR DESCRIPTION
- 어플리케이션 구동 시점에 에러 메시지 언어가 결정되는 문제 수정
- default properties가 english라서 Locale.getDefault()가 Locale.ENGLISH로 맞춰져야 하는데 user 환경 변수 LANG의 우선 순위가 더 높아서 실행 환경별로 Locale.getDefault()값이 바뀌는 문제 수정